### PR TITLE
Scaling Grape Finance Icon and other icons in the Navbar

### DIFF
--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -291,13 +291,11 @@ const Page: React.FC = ({children}) => {
   // }, [screenSM]);
 
   const changeBackground = (c: any) => {
-    c.target.style.transform = 'scale(1.01,1.1)';
-    c.target.style.backgroundColor = 'rgba(221,160,221,0.3)';
+    c.target.style.transform = 'scale(1.035)';
   };
 
   const resetBackground = (r: any) => {
     r.target.style.transform = 'scale(1,1)';
-    r.target.style.background = 'transparent';
   };
 
   return (

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -290,6 +290,16 @@ const Page: React.FC = ({children}) => {
   //   }
   // }, [screenSM]);
 
+  const changeBackground = (c: any) => {
+    c.target.style.transform = 'scale(1.01,1.1)';
+    c.target.style.backgroundColor = 'rgba(221,160,221,0.3)';
+  };
+
+  const resetBackground = (r: any) => {
+    r.target.style.transform = 'scale(1,1)';
+    r.target.style.background = 'transparent';
+  };
+
   return (
     <div style={{position: 'relative', minHeight: '100vh'}}>
       <Box sx={{display: 'flex'}}>
@@ -519,6 +529,8 @@ const Page: React.FC = ({children}) => {
                 src={grapeLogo}
                 width={drawerWidth}
                 style={{paddingLeft: '9px', paddingRight: '10px'}}
+                onMouseOver={changeBackground}
+                onMouseOut={resetBackground}
               />
             </Tooltip>
           </Link>

--- a/src/index.css
+++ b/src/index.css
@@ -108,8 +108,10 @@ h6 {
   color: #000;
 }
 
-.MuiList-padding:hover {
-  background: rgba(221,160,221,0.3);
+.MuiSvgIcon-root:hover,
+.MuiTypography-root:hover,
+.MuiListItemIcon-root:hover {
+  transform: scale(1.1);
 }
 
 .MuiButton-containedPrimary,

--- a/src/index.css
+++ b/src/index.css
@@ -108,6 +108,10 @@ h6 {
   color: #000;
 }
 
+.MuiList-padding:hover {
+  background: rgba(221,160,221,0.3);
+}
+
 .MuiButton-containedPrimary,
 .MuiButton-containedPrimary:hover,
 .MuiListItem-button:hover,


### PR DESCRIPTION
I am completely removing the highlights of the navbar slots and instead scaling the icons within the navbar, starting at the expand icon in the very top left.